### PR TITLE
Remove combine pindel typo

### DIFF
--- a/combine_pindel_vcfs.sh
+++ b/combine_pindel_vcfs.sh
@@ -1,5 +1,5 @@
 DOI=$1
 FOIS=( $(ls $DOI/*vcf | egrep -e '(pindel_LI|pindel_RP|pindel_SI|pindel_TD|pindel_INV|pindel_INT_final|pindel_D)') )
 FINAL_FILE=$DOI"/pindel_all.vcf"
-VCFS_STR=for i in "$(FOIS[*]}"; do echo "$i"; done
+VCFS_STR=for i in "${FOIS[*]}"; do echo "$i"; done
 vcf-concat -p $VCFS_STR >  $FINAL_FILE


### PR DESCRIPTION
Replace mismatched bracket. Script is used in TSO500 pipeline.

Closes #14 