### PR TITLE
Update CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-title: Bridge2AI Voice Docs
+title: eipm/bioinformatics
 message: >-
   If you use this software, please cite it using the
   metadata from this file.
@@ -14,13 +14,13 @@ authors:
     email: als2076@med.cornell.edu
     affiliation: Weill Cornell Medicine (WCM)
     orcid: 'https://orcid.org/0000-0002-7607-559X'
-  - family-names: Gorsky
+  - family-names: Gorski
     given-names: Kathryn
     affiliation: Weill Cornell Medicine (WCM)
     orcid: 'https://orcid.org/0009-0005-6277-9691'
 identifiers:
   - type: doi
-    value: 10.5281/zenodo.12760724
+    value: 10.5281/zenodo.14968809
 repository-code: 'https://github.com/eipm/bioinformatics'
 keywords:
   - Bioinformatics


### PR DESCRIPTION
fix name, title

This pull request includes updates to the `CITATION.cff` file to correct author information and update metadata. The most important changes are:

Metadata updates:

* Changed the title from "Bridge2AI Voice Docs" to "eipm/bioinformatics".
* Updated the DOI value from "10.5281/zenodo.12760724" to "10.5281/zenodo.14968809".

Author information corrections:

* Corrected the family name of one of the authors from "Gorsky" to "Gorski".